### PR TITLE
edited cable-highspeed to cable-64k in button properties

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
         <div class="alert alert-danger hidden" data-quiet-receive-image-warning></div>
         <p data-quiet-receive-image-target class="hidden">Your received image will show up here. Waiting...</p>
         <div class="form-group">
-          <button type="button" class="btn btn-default" style="width:100%" data-quiet-receive-image-button data-quiet-receiving-text="Listening..." data-quiet-profile-name="cable-highspeed">Start Receiver</button>
+          <button type="button" class="btn btn-default" style="width:100%" data-quiet-receive-image-button data-quiet-receiving-text="Listening..." data-quiet-profile-name="cable-64k">Start Receiver</button>
         </div>
 
         <pre style="border: unset; border-radius: unset;">Send Image</pre>


### PR DESCRIPTION
When I was trying out the live demo, I noticed the image transfer was not working (this is also documented as an issue by someone else). When I looked into it, I found the error simply to be that the profile name used for the image receiver "cable-highspeed" did not match the one for the image transmitter "cable-64k"

Looking at the profiles JSON file, it seems like "cable-highspeed" does not exist, but "cable-64k" does. Once I made the change, the image transfer worked on my local working copy of the live example.