### PR TITLE
#20: Adding a functionality to download transmissions as .wav files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 libfec.js
+
+.idea

--- a/examples/text/sendtext.html
+++ b/examples/text/sendtext.html
@@ -5,9 +5,9 @@
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <title>Send Text</title>
 
-    <script type="text/javascript" src="/quiet.js"></script>
+    <script type="text/javascript" src="../../quiet.js"></script>
     <script type="text/javascript" src="sendtext.js"></script>
-    <script async type="text/javascript" src="/quiet-emscripten.js"></script>
+    <script async type="text/javascript" src="../../quiet-emscripten.js"></script>
   </head>
   <body>
     <div class="hidden" data-quiet-profile-name="audible"></div>

--- a/examples/text/sendtext.js
+++ b/examples/text/sendtext.js
@@ -1,7 +1,7 @@
 var TextTransmitter = (function() {
     Quiet.init({
-        profilesPrefix: "/",
-        memoryInitializerPrefix: "/",
+        profilesPrefix: "/quiet-js/",
+        memoryInitializerPrefix: "/quiet-js/",
         libfecPrefix: "/"
     });
     var btn;
@@ -34,7 +34,13 @@ var TextTransmitter = (function() {
 
     function onQuietReady() {
         var profilename = document.querySelector('[data-quiet-profile-name]').getAttribute('data-quiet-profile-name');
-        transmit = Quiet.transmitter({profile: profilename, onFinish: onTransmitFinish});
+        transmit = Quiet.transmitter({
+            profile: profilename,
+            clampFrame: false,
+            onFinish: onTransmitFinish,
+            downloadableTransmissionFileName: 'transmission.wav',
+            downloadTransmission: true,
+        });
         btn.addEventListener('click', onClick, false);
     };
 


### PR DESCRIPTION
The goal is to allow record transmissions, this resolves #20 issue.

With the following changes now you can set the following 2 new parameters for the transmitter:
- **downloadTransmission** - type: boolean, default: **false**, indicates if the generated sound needs to be downloaded after its transmission, 
- **downloadableTransmissionFileName** - type: string, default: **"transmission.wav"**, set's downloadable file's name.

Example:
```
const transmit = Quiet.transmitter({
    profile: profilename,
    clampFrame: false,
    onFinish: onTransmitFinish,
    downloadableTransmissionFileName: 'transmission.wav',
    downloadTransmission: true,
});
```